### PR TITLE
Return leak

### DIFF
--- a/src/testit/SuiteRunner.groovy
+++ b/src/testit/SuiteRunner.groovy
@@ -72,7 +72,7 @@ class SuiteRunner implements Serializable {
         final method = source.class.getDeclaredMethods().find { it.isAnnotationPresent(annotation) }?.getName()
 
         if (!method)
-            return
+            return null
 
         final result = new TestResult(
             classname: testRunner.getClassname(source),

--- a/src/testit/TestRunner.groovy
+++ b/src/testit/TestRunner.groovy
@@ -90,10 +90,11 @@ class TestRunner implements Serializable {
         final method = source.class.getDeclaredMethods().find { it.isAnnotationPresent(annotation) }?.getName()
 
         if (!method)
-            return
+            return null
 
         try {
             ReflectionUtils.invokeMethod(source, method)
+            return null
         } catch (Throwable error) {
             return StepResult.errored(error)
         }

--- a/src/testit/TestRunner.groovy
+++ b/src/testit/TestRunner.groovy
@@ -68,6 +68,7 @@ class TestRunner implements Serializable {
         
         try {
             ReflectionUtils.invokeMethod(source, method)
+            return null
         } catch (AssertionError error) {
             return StepResult.failed(error)
         } catch (Throwable error) {


### PR DESCRIPTION
Groovy (or possibly just CPS) ignores the return type. I ran into an issue where the test method called a method that returned a value. This value propagated up until causing a fault at the JUnitConverter step.